### PR TITLE
Output dir

### DIFF
--- a/bin/imgsplit
+++ b/bin/imgsplit
@@ -91,9 +91,10 @@ def main(image, outpat, bs=512, minskip=1024):
         out.close()
         out = None
 
-def out_pattern_for(image):
-    base, ext = os.path.splitext(image)
-    return ''.join([base, '_0x%08x', ext])
+def out_pattern_for(image,targetdir):
+    filename=os.path.basename(image)
+    base, ext = os.path.splitext(filename)
+    return os.path.join(targetdir,''.join([base, '_0x%08x', ext]))
 
 if __name__ == "__main__":
     args = docopt.docopt(
@@ -101,9 +102,15 @@ if __name__ == "__main__":
         version="version "+__version__
     )
 
-    bs      = int(args.get('--bs'))
-    minskip = int(args.get('--minskip'))
-    image   = args.get('<image>')
-    outpat  = args.get('<outpattern>') or out_pattern_for(image)
+    bs        = int(args.get('--bs'))
+    minskip   = int(args.get('--minskip'))
+    image     = args.get('<image>')
+    outpat    = args.get('<outpattern>')
+    targetdir = os.getcwd()
+
+    if outpat:
+        outpat = os.path.join(targetdir,outpat)
+    else:
+        outpat = out_pattern_for(image,targetdir)
 
     main(image, outpat, bs=bs, minskip=minskip)

--- a/bin/imgsplit
+++ b/bin/imgsplit
@@ -19,12 +19,13 @@ null or zero bytes.
 
 Usage:
     imgsplit (--version|--help)
-    imgsplit [--bs BS] [--minskip MINSKIP] <image> [<outpattern>]
+    imgsplit [--bs BS] [--minskip MINSKIP] <image> [--targetdir targetdir] [<outpattern>]
 
 Arguments:
     --bs BS            Block size in bytes. Segments are aligned to this size. [default: 512]
     --minskip MINSKIP  Minimum number of zero blocks to skip. [default: 1024]
     <image>            Image file to split.
+    --targetdir targetdir The folder to write the image segments to. Will be ignored if outpattern is specified. [default: cwd]
     <outpattern>       Pattern for naming the segment files. Will be expanded with the segment offset. E.g `image_%08x.img`.
 
 Example:
@@ -106,7 +107,7 @@ if __name__ == "__main__":
     minskip   = int(args.get('--minskip'))
     image     = args.get('<image>')
     outpat    = args.get('<outpattern>')
-    targetdir = os.getcwd()
+    targetdir = args.get('--targetdir') or os.getcwd()
 
     if outpat:
         outpat = os.path.join(targetdir,outpat)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = REAdME.md
+description-file = README.md


### PR DESCRIPTION
Currently imgsplit outputs the image parts into the folder that the incoming image resides. I think it would be better default behavior to output to the current working directory. Additionally the output directory is part of outpattern, I think creating another parameter to separate them would be helpful. 